### PR TITLE
Write header documentation, first pass

### DIFF
--- a/Parse-RACExtensions/PFAnonymousUtils+RACExtensions.h
+++ b/Parse-RACExtensions/PFAnonymousUtils+RACExtensions.h
@@ -12,6 +12,11 @@
 
 @interface PFAnonymousUtils (RACExtensions)
 
+/// Creates an anonymous user.
+///
+/// @see +logInWithBlock:
+///
+/// @return A signal that sends the anonymous PFUser on successful login.
 + (RACSignal *)rac_logIn;
 
 @end

--- a/Parse-RACExtensions/PFCloud+RACExtensions.h
+++ b/Parse-RACExtensions/PFCloud+RACExtensions.h
@@ -12,6 +12,13 @@
 
 @interface PFCloud (RACExtensions)
 
+/// Calls the given cloud function with the parameters provided.
+///
+/// @see +callFunctionInBackground:withParameters:block:
+///
+/// @param function The function name to call.
+/// @param parameters The parameters to send to the function.
+/// @return A signal that sends the function's return value.
 + (RACSignal *)rac_callFunction:(NSString *)function withParameters:(NSDictionary *)parameters;
 
 @end

--- a/Parse-RACExtensions/PFFile+RACExtensions.h
+++ b/Parse-RACExtensions/PFFile+RACExtensions.h
@@ -12,8 +12,31 @@
 
 @interface PFFile (RACExtensions)
 
+/// Saves the file.
+///
+/// @see -saveInBackgroundWithBlock:progressBlock:
+///
+/// @return A signal that "periodically" sends percent progress. The signal will
+/// send 100 percent before completing.
 - (RACSignal *)rac_save;
+
+/// Gets the data, either from cache if available, or, fetches its contents from
+/// the Parse servers.
+///
+/// @see -getDataInBackgroundWithBlock:progressBlock:
+///
+/// @return A signal that "periodically" sends percent progress. The signal will
+/// send 100 percent before completing.
 - (RACSignal *)rac_getData;
+
+/// This method is like -rac_getData but avoids ever holding the entire contents
+/// of the PFFile in memory at once. This can help apps with many large PFFiles
+/// avoid memory warnings.
+///
+/// @see -getDataStreamInBackgroundWithBlock:progressBlock:
+///
+/// @return A signal that "periodically" sends percent progress. The signal will
+/// send 100 percent before completing.
 - (RACSignal *)rac_getDataStream;
 
 @end

--- a/Parse-RACExtensions/PFGeoPoint+RACExtensions.h
+++ b/Parse-RACExtensions/PFGeoPoint+RACExtensions.h
@@ -12,6 +12,11 @@
 
 @interface PFGeoPoint (RACExtensions)
 
+/// Fetches the device's current location
+///
+/// @see +geoPointForCurrentLocationInBackground:
+///
+/// @return A signal which sends a PFGeoPoint representing the current location.
 + (RACSignal *)rac_geoPointForCurrentLocation;
 
 @end

--- a/Parse-RACExtensions/PFObject+RACExtensions.h
+++ b/Parse-RACExtensions/PFObject+RACExtensions.h
@@ -12,15 +12,87 @@
 
 @interface PFObject (RACExtensions)
 
+/*! @name Batch Operations */
+
+/// Saves a collection of objects all at once.
+///
+/// @see +saveAllInBackground:block:
+///
+/// @param objects The list of objects to save.
+/// @return A signal that completes on successful save.
 + (RACSignal *)rac_saveAll:(NSArray *)objects;
+
+/// Fetches all of the current data from the server for all of the PFObjects.
+///
+/// @see +fetchAllInBackground:block:
+///
+/// @param objects The list of objects to fetch.
+/// @return A signal that sends the fetched objects.
 + (RACSignal *)rac_fetchAll:(NSArray *)objects;
+
+/// Fetches the current data from the server for the PFObjects whose
+/// isDataAvailable is false.
+///
+/// @see +fetchAllIfNeededInBackground:block:
+///
+/// @param objects The list of objects to fetch.
+/// @return A signal that sends the fetched objects.
 + (RACSignal *)rac_fetchAllIfNeeded:(NSArray *)objects;
 
+/*! Object Data Operations */
+
+/// Saves the PFObject.
+///
+/// @see -saveInBackgroundWithBlock:
+///
+/// @return A signal that completes on successful save.
 - (RACSignal *)rac_save;
+
+/// Saves this object to the server at some unspecified time in the future, even
+/// if Parse is currently inaccessible. Use this when you may not have a solid
+/// network connection, and don't need to know when the save completes. If there
+/// is some problem with the object such that it can't be saved, it will be
+/// silently discarded. If the save completes successfully while the object is
+/// still in memory, then callback will be called.
+///
+/// Objects saved with this method will be stored locally in an on-disk cache
+/// until they can be delivered to Parse. They will be sent immediately if
+/// possible. Otherwise, they will be sent the next time a network connection is
+/// available. Objects saved this way will persist even after the app is closed,
+/// in which case they will be sent the next time the app is opened.  If more
+/// than 10MB of data is waiting to be sent, subsequent calls to saveEventually
+/// will cause old saves to be silently discarded until the connection can be
+/// re-established, and the queued objects can be saved.
+///
+/// @see -saveEventually:
 - (RACSignal *)rac_saveEventually;
+
+/// Refreshes the PFObject with the current data from the server.
+///
+/// @see -fetchInBackgroundWithBlock:
+///
+/// @return A signal that sends the refreshed object.
 - (RACSignal *)rac_refresh;
+
+/// Fetches the PFObject.
+///
+/// @see -fetchInBackgroundWithBlock:
+///
+/// @return A signal that sends the fetched object.
 - (RACSignal *)rac_fetch;
+
+/// Fetches the PFObject if isDataAvailable is false.
+///
+/// @see -fetchIfNeededInBackgroundWithBlock:
+///
+/// @return A signal that sends the fetched object.
 - (RACSignal *)rac_fetchIfNeeded;
+
+/// Deletes the PFObject.
+///
+/// @see -deleteInBackgroundWithBlock:
+///
+/// @return A signal that completes on successful save.
 - (RACSignal *)rac_delete;
 
 @end

--- a/Parse-RACExtensions/PFPush+RACExtensions.h
+++ b/Parse-RACExtensions/PFPush+RACExtensions.h
@@ -13,15 +13,84 @@
 
 @interface PFPush (RACExtensions)
 
-+ (RACSignal *)rac_sendPushMessageToChannel:(NSString *)channel withMessage:(NSString *)message;
-+ (RACSignal *)rac_sendPushMessageToQuery:(PFQuery *)query withMessage:(NSString *)message;
-+ (RACSignal *)rac_sendPushDataToChannel:(NSString *)channel withData:(NSDictionary *)data;
-+ (RACSignal *)rac_sendPushDataToQuery:(PFQuery *)query withData:(NSDictionary *)data;
-+ (RACSignal *)rac_getSubscribedChannels;
-+ (RACSignal *)rac_subscribeToChannel:(NSString *)channel;
-+ (RACSignal *)rac_unsubscribeFromChannel:(NSString *)channel;
+/*! @name Sending Push Notifications */
 
+/// Sends a push message to a channel.
+///
+/// @see +sendPushMessageToChannelInBackground:withMessage:block:
+///
+/// @param channel The channel to send to. The channel name must start with a
+/// letter and contain only letters, numbers, dashes, and underscores.
+/// @param message The message to send.
+/// @return A signal that completes on successfully message delivery.
++ (RACSignal *)rac_sendPushMessageToChannel:(NSString *)channel withMessage:(NSString *)message;
+
+/// Sends a push message to a query.
+///
+/// @see +sendPushMessageToChannelInBackground:withMessage:block:
+///
+/// @param query The query to send to. The query must be a PFInstallation query
+/// created with [PFInstallation query].
+/// @param message The message to send.
+/// @return A signal that completes on successfully message delivery.
++ (RACSignal *)rac_sendPushMessageToQuery:(PFQuery *)query withMessage:(NSString *)message;
+
+/// Send a push message with arbitrary data to a channel.
+///
+/// See the guide for information about the dictionary structure.
+///
+/// @see +sendPushDataToChannelInBackground:withData:block:
+///
+/// @param channel The channel to send to. The channel name must start with a
+/// letter and contain only letters, numbers, dashes, and underscores.
+/// @param data The data to send.
+/// @return A signal that completes on successfully message delivery.
++ (RACSignal *)rac_sendPushDataToChannel:(NSString *)channel withData:(NSDictionary *)data;
+
+/// Send a push message with arbitrary data to a query.
+///
+/// See the guide for information about the dictionary structure.
+///
+/// @see +sendPushDataToChannelInBackground:withData:block:
+///
+/// @param query The query to send to. The query must be a PFInstallation query
+/// created with [PFInstallation query].
+/// @param data The data to send.
+/// @return A signal that completes on successfully message delivery.
++ (RACSignal *)rac_sendPushDataToQuery:(PFQuery *)query withData:(NSDictionary *)data;
+
+/// Send this push message.
+///
+/// @see -sendPushInBackgroundWithBlock:
+///
+/// @return A signal that completes on successful message delivery.
 - (RACSignal *)rac_sendPush;
 
+/*! @name Managing Channel Subscriptions */
+
+/// Get all the channels that this device is subscribed to.
+///
+/// @see +getSubscribedChannelsInBackgroundWithBlock:
+///
+/// @return A signal that sends the NSSet of subscribed channel names.
++ (RACSignal *)rac_getSubscribedChannels;
+
+/// Subscribes the device to a channel of push notifications.
+///
+/// @see +subscribeToChannelInBackground:block:
+///
+/// @param channel The channel to send to. The channel name must start with a
+/// letter and contain only letters, numbers, dashes, and underscores.
+/// @return A signal that completes on successful subscription.
++ (RACSignal *)rac_subscribeToChannel:(NSString *)channel;
+
+/// Unsubscribes the device from a channel of push notifications.
+///
+/// @see +unsubscribeFromChannelInBackground:block:
+///
+/// @param channel The channel to send to. The channel name must start with a
+/// letter and contain only letters, numbers, dashes, and underscores.
+/// @return A signal that completes on successful unsubscription.
++ (RACSignal *)rac_unsubscribeFromChannel:(NSString *)channel;
 
 @end

--- a/Parse-RACExtensions/PFQuery+RACExtensions.h
+++ b/Parse-RACExtensions/PFQuery+RACExtensions.h
@@ -12,9 +12,36 @@
 
 @interface PFQuery (RACExtensions)
 
+/// Gets a PFObject with the given id.
+///
+/// @warning This mutates the PFQuery.
+///
+/// @see -getObjectInBackgroundWithId:block:
+///
+/// @return A signal that sends the identified PFObject.
 - (RACSignal *)rac_getObjectWithId:(NSString *)objectId;
+
+/// Finds objects based on the constructed query.
+///
+/// @see -findObjectsInBackgroundWithBlock:
+///
+/// @return A signal that sends the NSArray of matching PFObjects.
 - (RACSignal *)rac_findObjects;
+
+/// Gets an object based on the constructed query.
+///
+/// @warning This mutates the PFQuery.
+///
+/// @see -getFirstObjectInBackgroundWithBlock:
+///
+/// @return A signal that sends the first matching PFObject.
 - (RACSignal *)rac_getFirstObject;
+
+/// Counts objects based on the constructed query.
+///
+/// @see -countObjectsInBackgroundWithBlock:
+///
+/// @return A signal that sends the integer count of matching PFObjects
 - (RACSignal *)rac_countObjects;
 
 @end

--- a/Parse-RACExtensions/PFUser+RACExtensions.h
+++ b/Parse-RACExtensions/PFUser+RACExtensions.h
@@ -12,9 +12,37 @@
 
 @interface PFUser (RACExtensions)
 
+/// Makes a request to log in a user with specified credentials.
+///
+/// This method will also cache the user locally so that calls to
+/// userFromCurrentUser will use the latest logged in user.
+///
+/// @see +logInWithUsernameInBackground:password:
+///
+/// @param username The username of the user.
+/// @param password The password of the user.
+/// @return A signal that sends the successfully logged in PFUser.
 + (RACSignal *)rac_logInWithUsername:(NSString *)username password:(NSString *)password;
+
+/// Send a password reset request for a specified email.
+///
+/// If a user account exists with that email, an email will be sent to that
+/// address with instructions on how to reset their password.
+///
+/// @see +logInWithUsernameInBackground:password:
+///
+/// @param email Email of the account to send a reset password request.
+/// @return A signal that completes on success.
 + (RACSignal *)rac_requestPasswordResetForEmail:(NSString *)email;
 
+/// Signs up the user.
+///
+/// Make sure that password and username are set. This will also enforce that
+/// the username isn't already taken.
+///
+/// @see +signUpInBackgroundWithBlock:
+///
+/// @return A signal that completes on successful sign-up.
 - (RACSignal *)rac_signUp;
 
 @end


### PR DESCRIPTION
Resolves #4.

Uses [appledoc](https://github.com/tomaz/appledoc) format, with `///`-comments for layout consistency.
